### PR TITLE
feat: Apply new UI color scheme and logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
   </head>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,18 @@
+<svg width="360" height="120" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="100%" height="100%" fill="#ffffff"/>
+
+  <!-- Chat Icon -->
+  <path d="M40,20 h60 a10,10 0 0 1 10,10 v40 a10,10 0 0 1 -10,10 h-25 l-15,15 v-15 h-20 a10,10 0 0 1 -10,-10 v-40 a10,10 0 0 1 10,-10 z" fill="#2C3E50"/>
+
+  <!-- Document inside chat icon -->
+  <rect x="55" y="30" width="30" height="40" rx="4" ry="4" fill="white"/>
+  <rect x="60" y="36" width="20" height="5" rx="2" fill="#F1C40F"/>
+  <rect x="60" y="45" width="20" height="10" rx="2" fill="#E74C3C"/>
+  <path d="M65 60 l5 6 l10 -10" stroke="#27AE60" stroke-width="3" fill="none"/>
+
+  <!-- Brand Text -->
+  <text x="120" y="60" font-family="sans-serif" font-size="30" font-weight="bold" fill="#2C3E50">Impuest</text>
+  <text x="248" y="60" font-family="sans-serif" font-size="30" font-weight="bold" fill="#2C3E50">IA</text>
+  <text x="120" y="90" font-family="sans-serif" font-size="16" fill="#2C3E50">Tu asistente fiscal digital</text>
+</svg>

--- a/src/App.css
+++ b/src/App.css
@@ -5,34 +5,6 @@
   text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
 .card {
   padding: 2em;
 }

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,7 +1,7 @@
 import { ThemeProviderContext } from "@/context/ThemeProviderContext";
 import { useEffect, useState, type ReactNode } from "react";
 
-type Theme = "light" | "dark" | "system";
+type Theme = "light";
 
 // src/components/ThemeProvider.tsx
 type ThemeProviderProps = {
@@ -12,37 +12,24 @@ type ThemeProviderProps = {
 
 export function ThemeProvider({
   children,
-  defaultTheme = "system",
+  defaultTheme = "light",
   storageKey = "ui-theme",
   ...props
 }: ThemeProviderProps) {
-  const [theme, setTheme] = useState<Theme>(
-    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
-  );
+  const [theme, setTheme] = useState<Theme>("light");
 
   useEffect(() => {
     const root = window.document.documentElement;
-
-    root.classList.remove("light", "dark");
-
-    if (theme === "system") {
-      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
-        .matches
-        ? "dark"
-        : "light";
-
-      root.classList.add(systemTheme);
-      return;
-    }
-
-    root.classList.add(theme);
-  }, [theme]);
+    root.classList.remove("dark");
+    root.classList.add("light");
+    localStorage.setItem(storageKey, "light"); // Persist that only light is active
+  }, [storageKey]); // theme can be removed from dependencies as it's always light
 
   const value = {
-    theme,
-    setTheme: (theme: Theme) => {
-      localStorage.setItem(storageKey, theme);
-      setTheme(theme);
+    theme: "light" as Theme, // Cast as Theme to satisfy type, actual is string "light"
+    setTheme: (newTheme: Theme) => { // newTheme will always be "light" due to type
+      localStorage.setItem(storageKey, "light");
+      setTheme("light");
     },
   };
 

--- a/src/index.css
+++ b/src/index.css
@@ -43,71 +43,37 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  --background: oklch(96.38% 0.005 253.08);
+  --foreground: oklch(32.84% 0.032 250.78);
+  --card: oklch(100% 0 0);
+  --card-foreground: oklch(32.84% 0.032 250.78);
+  --popover: oklch(100% 0 0);
+  --popover-foreground: oklch(32.84% 0.032 250.78);
+  --primary: oklch(32.84% 0.032 250.78);
+  --primary-foreground: oklch(100% 0 0);
+  --secondary: oklch(67.06% 0.158 151.02);
+  --secondary-foreground: oklch(100% 0 0);
+  --muted: oklch(58.05% 0.011 200.12);
+  --muted-foreground: oklch(32.84% 0.032 250.78);
+  --accent: oklch(81.39% 0.156 87.09);
+  --accent-foreground: oklch(32.84% 0.032 250.78);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --border: oklch(58.05% 0.011 200.12);
+  --input: oklch(100% 0 0);
+  --ring: oklch(67.06% 0.158 151.02);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
-}
-
-.dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --sidebar: oklch(96.38% 0.005 253.08);
+  --sidebar-foreground: oklch(32.84% 0.032 250.78);
+  --sidebar-primary: oklch(32.84% 0.032 250.78);
+  --sidebar-primary-foreground: oklch(100% 0 0);
+  --sidebar-accent: oklch(81.39% 0.156 87.09);
+  --sidebar-accent-foreground: oklch(32.84% 0.032 250.78);
+  --sidebar-border: oklch(58.05% 0.011 200.12);
+  --sidebar-ring: oklch(67.06% 0.158 151.02);
 }
 
 @layer base {

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -57,7 +57,7 @@ const MainLayout = ({ children }: MainLayoutProps) => {
         <div className="container mx-auto px-4 py-4">
           <div className="flex justify-between items-center">
             <Link to="/" className="flex items-center">
-              <span className="text-2xl font-bold text-blue-600">
+              <span className="text-2xl font-bold text-[var(--primary)]">
                 SpanishTaxBuddy
               </span>
             </Link>
@@ -133,7 +133,7 @@ const MainLayout = ({ children }: MainLayoutProps) => {
               <SheetContent side="right">
                 <div className="flex flex-col h-full py-4">
                   <div className="flex justify-between items-center mb-6">
-                    <span className="text-xl font-bold">SpanishTaxBuddy</span>
+                    <span className="text-xl font-bold text-[var(--primary)]">SpanishTaxBuddy</span>
                     <Button
                       variant="ghost"
                       size="icon"


### PR DESCRIPTION
This commit introduces a new visual identity to the application:

- **New Logo**:
    - Replaced the existing favicon (`vite.svg`) with a new brand logo (`logo.svg`).
    - Updated `index.html` to reference the new favicon.
    - Updated the text-based "SpanishTaxBuddy" logo in the main layout to use the new primary brand color.

- **New Color Scheme (Light Mode Only)**:
    - Implemented a new color palette based on your specifications: - Primary: Deep Blue (#2C3E50) - Secondary: Emerald Green (#27AE60) - Accent: Sunshine Yellow (#F1C40F) - Background: Light Gray (#F5F7FA) - Neutral: Cool Gray (#7F8C8D)
    - Updated CSS variables in `src/index.css` to reflect these new colors. All UI elements (buttons, text, backgrounds, cards, inputs, etc.) should now use this palette.

- **Dark Mode Removal**:
    - As per your request, the dark mode functionality has been completely removed.
    - Deleted dark theme styles from `src/index.css`.
    - Simplified `ThemeProvider.tsx` to enforce a light theme consistently.

- **CSS Cleanup**:
    - Removed obsolete CSS rules related to the old logo (e.g., hover effects, animations) from `src/App.css`.